### PR TITLE
Made kernel file bootable.

### DIFF
--- a/src/kernel.asm
+++ b/src/kernel.asm
@@ -1,2 +1,3 @@
 org 0x7C00  ; Add 0x7C00 (MBR loading address) to label addresses.
 times 510-($-$$) db 0   ; Pads current section with zeros.
+db 0x55, 0xaa


### PR DESCRIPTION
Necessary for function of OS. Dunce cap required.